### PR TITLE
Fix high CPU usage: GPU-composite flicker, reduce video/audio overhea…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v2.4 — 2026-03-31
+
+### Performance
+- **Fix extreme CPU usage from body-wide flicker animation** — the terminal flicker effect was animating opacity on the entire `<body>` every 150 ms, forcing full-page repaints over every video element. Moved the effect to a GPU-composited `::after` pseudo-element with `will-change: opacity` so it no longer triggers layout or paint on child nodes.
+- **Replace box-shadow speaking animation with GPU-friendly transform** — the speaking-pulse keyframes were animating multi-layer `box-shadow`, which cannot be composited and forces repaints per frame. Replaced with a `transform: scale()` animation that runs entirely on the compositor thread.
+- **Reduce audio-level monitoring overhead** — all per-stream audio monitors now share a single `AudioContext` instead of creating one each, and the polling interval was increased from 100 ms to 250 ms (60 % fewer FFT operations per second).
+- **Default video to 720p / 24 fps** — desktop capture constraints changed from 1080p / 30 fps to 720p / 24 fps (`max` still allows 1080p / 30 fps). Significantly reduces encode/decode CPU load in multi-party calls.
+- **Prefer H.264 codec for hardware acceleration** — video transceivers now call `setCodecPreferences()` to favour H.264, which has hardware encode/decode on Apple Silicon. VP8/VP9 fall back to software-only decoding on macOS.
+
+---
+
 ## v2.3 — 2026-03-25
 
 ### Bug Fixes

--- a/client/conference.js
+++ b/client/conference.js
@@ -625,9 +625,9 @@ class ConferenceClient {
             width: { ideal: 640, max: 1280 },
             height: { ideal: 480, max: 720 }
         } : {
-            width: { ideal: 1920, max: 1920 },
-            height: { ideal: 1080, max: 1080 },
-            frameRate: { ideal: 30, max: 30 }
+            width: { ideal: 1280, max: 1920 },
+            height: { ideal: 720, max: 1080 },
+            frameRate: { ideal: 24, max: 30 }
         };
     }
 
@@ -675,22 +675,29 @@ class ConferenceClient {
         return this.localStream;
     }
 
+    getSharedAudioContext() {
+        if (!this._sharedAudioCtx || this._sharedAudioCtx.state === 'closed') {
+            this._sharedAudioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        }
+        return this._sharedAudioCtx;
+    }
+
     monitorAudioLevel(stream, containerElement) {
-        // Close any existing AudioContext for this container
-        if (containerElement._monitorCtx) {
-            containerElement._monitorCtx.close().catch(() => {});
-            containerElement._monitorCtx = null;
+        // Disconnect any existing analyser nodes for this container
+        if (containerElement._monitorSource) {
+            containerElement._monitorSource.disconnect();
+            containerElement._monitorSource = null;
         }
 
-        // Increment generation so old RAF loops self-terminate when they next fire
+        // Increment generation so old loops self-terminate when they next fire
         containerElement._monitorGen = (containerElement._monitorGen || 0) + 1;
         const myGen = containerElement._monitorGen;
 
         try {
-            const audioContext = new (window.AudioContext || window.webkitAudioContext)();
-            containerElement._monitorCtx = audioContext;
+            const audioContext = this.getSharedAudioContext();
 
             const audioSource = audioContext.createMediaStreamSource(stream);
+            containerElement._monitorSource = audioSource;
             const analyser = audioContext.createAnalyser();
             analyser.fftSize = 64;
             audioSource.connect(analyser);
@@ -715,7 +722,7 @@ class ConferenceClient {
                     containerElement.classList.remove('speaking');
                 }
 
-                setTimeout(checkAudioLevel, 100);
+                setTimeout(checkAudioLevel, 250);
             };
 
             checkAudioLevel();
@@ -1346,6 +1353,25 @@ class ConferenceClient {
                 }
             }
         });
+
+        // Prefer H.264 for hardware-accelerated encode/decode on Apple Silicon
+        try {
+            const transceivers = pc.getTransceivers();
+            for (const transceiver of transceivers) {
+                if (transceiver.sender && transceiver.sender.track && transceiver.sender.track.kind === 'video') {
+                    const codecs = RTCRtpReceiver.getCapabilities('video')?.codecs;
+                    if (codecs) {
+                        const h264Codecs = codecs.filter(c => c.mimeType === 'video/H264');
+                        const otherCodecs = codecs.filter(c => c.mimeType !== 'video/H264');
+                        if (h264Codecs.length > 0) {
+                            transceiver.setCodecPreferences([...h264Codecs, ...otherCodecs]);
+                        }
+                    }
+                }
+            }
+        } catch (e) {
+            console.warn('Could not set codec preferences:', e);
+        }
 
         // Handle incoming tracks
         let streamAdded = false;

--- a/client/styles.css
+++ b/client/styles.css
@@ -568,16 +568,17 @@ body::before {
 
 .video-container.speaking {
     border-color: var(--secondary);
-    box-shadow: 0 0 20px var(--secondary), 0 0 40px var(--secondary), inset 0 0 10px rgba(0, 255, 255, 0.3);
+    box-shadow: 0 0 20px var(--secondary);
     animation: speakingPulse 0.5s ease-in-out infinite alternate;
+    will-change: transform;
 }
 
 @keyframes speakingPulse {
     0% {
-        box-shadow: 0 0 15px var(--secondary), 0 0 30px var(--secondary);
+        transform: scale(1);
     }
     100% {
-        box-shadow: 0 0 25px var(--secondary), 0 0 50px var(--secondary);
+        transform: scale(1.01);
     }
 }
 
@@ -1864,29 +1865,24 @@ body::before {
     gap: 16px;
 }
 
-/* Terminal flicker effect */
+/* Terminal flicker effect - applied to a composited overlay to avoid full-page repaints */
 @keyframes flicker {
-    0% {
-        opacity: 0.97;
-    }
-    5% {
-        opacity: 0.98;
-    }
-    10% {
-        opacity: 0.96;
-    }
-    15% {
-        opacity: 0.99;
-    }
-    20% {
-        opacity: 0.97;
-    }
-    100% {
-        opacity: 0.97;
-    }
+    0% { opacity: 0.03; }
+    5% { opacity: 0.02; }
+    10% { opacity: 0.04; }
+    15% { opacity: 0.01; }
+    20% { opacity: 0.03; }
+    100% { opacity: 0.03; }
 }
 
-body {
+body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background: black;
+    pointer-events: none;
+    z-index: 9999;
+    will-change: opacity;
     animation: flicker 0.15s infinite;
 }
 


### PR DESCRIPTION
Move body flicker animation to a composited ::after overlay, replace box-shadow speaking pulse with transform: scale(), share a single AudioContext across audio monitors (250 ms polling), default desktop video to 720p/24 fps, and prefer H.264 codec for hardware encode/decode 