### PR TITLE
Stereo screen-share audio, 4K, 256k audio, dev env + TURN credential hardening

### DIFF
--- a/client/app.html
+++ b/client/app.html
@@ -100,6 +100,7 @@
                             <option value="480">480p</option>
                             <option value="720" selected>720p</option>
                             <option value="1080">1080p</option>
+                            <option value="2160">4K</option>
                         </select>
                     </div>
                     <div class="options-item theme-selector">

--- a/client/conference.js
+++ b/client/conference.js
@@ -439,7 +439,7 @@ class ConferenceClient {
         const turnServer = isLocalhost ? 'localhost' : hostname;
 
         // PRIMARY_TURN_CREDENTIAL rotated by update-vps.sh on each deploy
-        const PRIMARY_TURN_CREDENTIAL = 'M6vxdxo7HkzpvTxVWX0auQe8vkVFUPi';
+        const PRIMARY_TURN_CREDENTIAL = 'TURN_CREDENTIAL_REDACTED';
         const localTurnConfig = {
             urls: [
                 `turn:${turnServer}:3479`,

--- a/client/conference.js
+++ b/client/conference.js
@@ -449,13 +449,15 @@ class ConferenceClient {
             credential: PRIMARY_TURN_CREDENTIAL
         };
 
+        // SECONDARY_TURN_CREDENTIAL rotated by update-vps.sh from .env (TURN2_PASSWORD) on each deploy
+        const SECONDARY_TURN_CREDENTIAL = 'TURN2_CREDENTIAL_REDACTED';
         const turn2Config = {
             urls: [
                 'turn:174.138.183.167:3479',
                 'turn:174.138.183.167:3479?transport=tcp'
             ],
             username: 'webrtc',
-            credential: '98iKctn6qPZBuUYwFt2uRMUZNu8ziJib'
+            credential: SECONDARY_TURN_CREDENTIAL
         };
 
         // Relay-only via both coturn servers. Asymmetric paths (server1↔server2)
@@ -3144,6 +3146,8 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
 
         try {
             this.stereoMixCtx = new AudioContext({ sampleRate: 48000 });
+            // Resume in case the context starts suspended (autoplay policy) — otherwise the mix is silent
+            if (this.stereoMixCtx.state === 'suspended') this.stereoMixCtx.resume().catch(() => {});
             const destination = this.stereoMixCtx.createMediaStreamDestination();
             destination.channelCount = 2;
 

--- a/client/conference.js
+++ b/client/conference.js
@@ -3067,6 +3067,10 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
                     }
                 });
 
+                // Auto-disable noise suppression during screen share (preserves audio fidelity)
+                this._nsWasEnabledBeforeScreenShare = this.noiseSuppressionEnabled;
+                if (this.noiseSuppressionEnabled) await this.toggleNoiseSuppression();
+
                 // If screen audio is available, mix it with mic and replace audio track
                 this.mixScreenAudio(this.screenStream);
 
@@ -3110,6 +3114,10 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
 
             // Restore original mic audio (unmix screen audio)
             this.unmixScreenAudio();
+
+            // Restore noise suppression if it was on before screen share
+            if (this._nsWasEnabledBeforeScreenShare) await this.toggleNoiseSuppression();
+            this._nsWasEnabledBeforeScreenShare = false;
 
             this.localVideo.srcObject = this.localStream;
             this.isScreenSharing = false;

--- a/client/conference.js
+++ b/client/conference.js
@@ -1233,7 +1233,7 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
             '480':  { width: { ideal: 854,  max: 854  }, height: { ideal: 480,  max: 480  }, frameRate: { ideal: 24, max: 30 } },
             '720':  { width: { ideal: 1280, max: 1280 }, height: { ideal: 720,  max: 720  }, frameRate: { ideal: 24, max: 30 } },
             '1080': { width: { ideal: 1920, max: 1920 }, height: { ideal: 1080, max: 1080 }, frameRate: { ideal: 24, max: 30 } },
-            '2160': { width: { min: 3840, ideal: 3840 }, height: { min: 2160, ideal: 2160 }, frameRate: { max: 30 } },
+            '2160': { width: { ideal: 3840 }, height: { ideal: 2160 }, frameRate: { ideal: 30, max: 30 } },
         };
         return qualityMap[this.videoQuality] || qualityMap['720'];
     }
@@ -1891,20 +1891,37 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
         console.log('Low bandwidth mode:', this.lowBandwidthMode ? 'ON' : 'OFF');
     }
 
-    setVideoQuality(quality) {
+    async setVideoQuality(quality) {
         this.videoQuality = quality;
         localStorage.setItem('broference-video-quality', quality);
 
         const stream = this.localStream || this.prejoinStream;
-        if (stream) {
-            const videoTrack = stream.getVideoTracks()[0];
-            if (videoTrack) {
-                videoTrack.applyConstraints(this.getVideoConstraints()).catch(err => {
-                    console.warn('Could not apply video quality constraints:', err);
-                });
+        if (!stream) return;
+
+        const oldTrack = stream.getVideoTracks()[0];
+        const deviceId = oldTrack?.getSettings().deviceId;
+        const constraints = { ...this.getVideoConstraints() };
+        if (deviceId) constraints.deviceId = { ideal: deviceId };
+
+        try {
+            const newStream = await navigator.mediaDevices.getUserMedia({ video: constraints });
+            const newTrack = newStream.getVideoTracks()[0];
+
+            if (oldTrack) {
+                oldTrack.stop();
+                stream.removeTrack(oldTrack);
             }
+            stream.addTrack(newTrack);
+
+            if (this.localVideo) this.localVideo.srcObject = stream;
+
+            this.peerConnections.forEach(peer => {
+                const sender = peer.connection.getSenders().find(s => s.track?.kind === 'video');
+                if (sender) sender.replaceTrack(newTrack);
+            });
+        } catch (err) {
+            console.warn('Could not switch video quality:', err);
         }
-        console.log('Video quality set to:', quality + 'p');
     }
 
 

--- a/client/conference.js
+++ b/client/conference.js
@@ -757,7 +757,8 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
 
             // Use ws:// for localhost, wss:// for production
             const protocol = isLocalhost ? 'ws' : 'wss';
-            const wsUrl = `${protocol}://${hostname}:8765`;
+            const wsPort = window.location.port === '8443' ? '8766' : '8765';
+            const wsUrl = `${protocol}://${hostname}:${wsPort}`;
 
             console.log(`Connecting to signaling server: ${wsUrl}`);
             this.ws = new WebSocket(wsUrl);

--- a/client/conference.js
+++ b/client/conference.js
@@ -3052,9 +3052,11 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
                         frameRate: { ideal: 30, max: 60 }
                     },
                     audio: {
-                        echoCancellation: true,
-                        noiseSuppression: true,
-                        sampleRate: 44100
+                        echoCancellation: false,
+                        noiseSuppression: false,
+                        autoGainControl: false,
+                        channelCount: 2,
+                        sampleRate: 48000
                     }
                 });
 
@@ -3071,8 +3073,8 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
                 this._nsWasEnabledBeforeScreenShare = this.noiseSuppressionEnabled;
                 if (this.noiseSuppressionEnabled) await this.toggleNoiseSuppression();
 
-                // If screen audio is available, mix it with mic and replace audio track
-                this.mixScreenAudio(this.screenStream);
+                // Mix mic + stereo screen audio and push to peers
+                this.startStereoScreenAudioMix(this.screenStream);
 
                 // Update local video to show screen
                 this.localVideo.srcObject = this.screenStream;
@@ -3112,8 +3114,8 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
                 }
             });
 
-            // Restore original mic audio (unmix screen audio)
-            this.unmixScreenAudio();
+            // Tear down stereo screen audio mix, restore mic track in senders
+            this.stopStereoScreenAudioMix();
 
             // Restore noise suppression if it was on before screen share
             if (this._nsWasEnabledBeforeScreenShare) await this.toggleNoiseSuppression();
@@ -3133,44 +3135,41 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
         }
     }
 
-    mixScreenAudio(screenStream) {
+    startStereoScreenAudioMix(screenStream) {
         const screenAudioTracks = screenStream.getAudioTracks();
         if (screenAudioTracks.length === 0) {
-            console.log('No screen audio available to mix');
-            return;
-        }
-        if (!this.micAudioCtx || !this.micDestination) {
-            console.log('Mic audio chain not ready, skipping mix');
+            console.log('No screen audio available');
             return;
         }
 
         try {
-            // Add screen audio into the existing micAudioCtx so both sources feed
-            // micDestination — the track peers already receive — avoiding cross-context
-            // audio piping which silences the mic in all browsers.
-            this.screenGainNode = this.micAudioCtx.createGain();
-            this.screenAudioSource = this.micAudioCtx.createMediaStreamSource(new MediaStream([screenAudioTracks[0]]));
-            this.screenAudioSource.connect(this.screenGainNode);
-            this.screenGainNode.connect(this.micDestination);
+            this.stereoMixCtx = new AudioContext({ sampleRate: 48000 });
+            const destination = this.stereoMixCtx.createMediaStreamDestination();
+            destination.channelCount = 2;
 
-            // Insert a gain node into the mic path for independent volume control.
-            // Disconnect micSource and rewire: micSource → micGainNode → [noiseNode →] micDestination
-            if (this.micSource) {
-                this.micSource.disconnect();
-                this.micGainNode = this.micAudioCtx.createGain();
-                if (this.noiseSuppressionEnabled && this.noiseSuppressionNode) {
-                    this.micSource.connect(this.micGainNode);
-                    this.micGainNode.connect(this.noiseSuppressionNode);
-                    // noiseSuppressionNode → micDestination already wired
-                } else {
-                    this.micSource.connect(this.micGainNode);
-                    this.micGainNode.connect(this.micDestination);
-                }
+            // Screen audio (stereo)
+            this.stereoScreenGain = this.stereoMixCtx.createGain();
+            const screenSource = this.stereoMixCtx.createMediaStreamSource(new MediaStream([screenAudioTracks[0]]));
+            screenSource.connect(this.stereoScreenGain);
+            this.stereoScreenGain.connect(destination);
+
+            // Mic audio (raw mono track — browser auto-upmixes to both channels)
+            const micTrack = this.localStream?.getAudioTracks()[0];
+            if (micTrack) {
+                this.stereoMicGain = this.stereoMixCtx.createGain();
+                const micSource = this.stereoMixCtx.createMediaStreamSource(new MediaStream([micTrack]));
+                micSource.connect(this.stereoMicGain);
+                this.stereoMicGain.connect(destination);
             }
 
-            // micDestination.stream is already the track in all peer senders — no replaceTrack needed.
+            // Push stereo track to all peer senders
+            this.stereoMixTrack = destination.stream.getAudioTracks()[0];
+            this.peerConnections.forEach(peer => {
+                const sender = peer.connection.getSenders().find(s => s.track?.kind === 'audio');
+                if (sender) sender.replaceTrack(this.stereoMixTrack);
+            });
 
-            // Show audio mixer UI and wire sliders
+            // Wire mixer UI
             const mixer = document.getElementById('screenAudioMixer');
             if (mixer) {
                 mixer.classList.remove('hidden');
@@ -3183,43 +3182,38 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
                 micVal.textContent = '100%';
                 screenVal.textContent = '100%';
                 micSlider.oninput = (e) => {
-                    if (this.micGainNode) this.micGainNode.gain.value = e.target.value / 100;
+                    if (this.stereoMicGain) this.stereoMicGain.gain.value = e.target.value / 100;
                     micVal.textContent = e.target.value + '%';
                 };
                 screenSlider.oninput = (e) => {
-                    this.screenGainNode.gain.value = e.target.value / 100;
+                    if (this.stereoScreenGain) this.stereoScreenGain.gain.value = e.target.value / 100;
                     screenVal.textContent = e.target.value + '%';
                 };
             }
 
-            console.log('Screen audio mixed with mic audio');
+            console.log('Stereo screen audio mix started');
         } catch (error) {
-            console.error('Error mixing screen audio:', error);
+            console.error('Error starting stereo screen audio mix:', error);
         }
     }
 
-    unmixScreenAudio() {
-        if (!this.screenAudioSource) return;
+    stopStereoScreenAudioMix() {
+        if (!this.stereoMixCtx) return;
 
-        // Disconnect screen audio branch
-        this.screenAudioSource.disconnect();
-        this.screenAudioSource = null;
-        this.screenGainNode = null;
-
-        // Remove mic gain node and restore direct mic chain
-        if (this.micSource && this.micGainNode) {
-            this.micSource.disconnect();
-            this.micGainNode.disconnect();
-            this.micGainNode = null;
-            if (this.noiseSuppressionEnabled && this.noiseSuppressionNode) {
-                this.micSource.connect(this.noiseSuppressionNode);
-                // noiseSuppressionNode → micDestination already wired
-            } else {
-                this.micSource.connect(this.micDestination);
-            }
+        // Restore mic track in all peer senders
+        const micTrack = this.micDestination?.stream.getAudioTracks()[0];
+        if (micTrack) {
+            this.peerConnections.forEach(peer => {
+                const sender = peer.connection.getSenders().find(s => s.track?.kind === 'audio');
+                if (sender) sender.replaceTrack(micTrack);
+            });
         }
 
-        // micDestination.stream track is already in all peer senders — no replaceTrack needed.
+        this.stereoMixCtx.close();
+        this.stereoMixCtx = null;
+        this.stereoMixTrack = null;
+        this.stereoScreenGain = null;
+        this.stereoMicGain = null;
 
         const mixer = document.getElementById('screenAudioMixer');
         if (mixer) mixer.classList.add('hidden');

--- a/client/conference.js
+++ b/client/conference.js
@@ -1233,6 +1233,7 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
             '480':  { width: { ideal: 854,  max: 854  }, height: { ideal: 480,  max: 480  }, frameRate: { ideal: 24, max: 30 } },
             '720':  { width: { ideal: 1280, max: 1280 }, height: { ideal: 720,  max: 720  }, frameRate: { ideal: 24, max: 30 } },
             '1080': { width: { ideal: 1920, max: 1920 }, height: { ideal: 1080, max: 1080 }, frameRate: { ideal: 24, max: 30 } },
+            '2160': { width: { ideal: 3840, max: 3840 }, height: { ideal: 2160, max: 2160 }, frameRate: { ideal: 24, max: 30 } },
         };
         return qualityMap[this.videoQuality] || qualityMap['720'];
     }

--- a/client/conference.js
+++ b/client/conference.js
@@ -1233,7 +1233,7 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
             '480':  { width: { ideal: 854,  max: 854  }, height: { ideal: 480,  max: 480  }, frameRate: { ideal: 24, max: 30 } },
             '720':  { width: { ideal: 1280, max: 1280 }, height: { ideal: 720,  max: 720  }, frameRate: { ideal: 24, max: 30 } },
             '1080': { width: { ideal: 1920, max: 1920 }, height: { ideal: 1080, max: 1080 }, frameRate: { ideal: 24, max: 30 } },
-            '2160': { width: { ideal: 3840, max: 3840 }, height: { ideal: 2160, max: 2160 }, frameRate: { ideal: 24, max: 30 } },
+            '2160': { width: { min: 3840, ideal: 3840 }, height: { min: 2160, ideal: 2160 }, frameRate: { max: 30 } },
         };
         return qualityMap[this.videoQuality] || qualityMap['720'];
     }

--- a/client/conference.js
+++ b/client/conference.js
@@ -1962,7 +1962,7 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
 
     applyBandwidthToSenders() {
         const videoBitrate = this.lowBandwidthMode ? 200000 : undefined; // 200kbps or uncapped
-        const audioBitrate = (this.lowBandwidthMode || this.isMobileDevice()) ? 64000 : 128000; // 64kbps mobile/low-band, 128kbps desktop
+        const audioBitrate = (this.lowBandwidthMode || this.isMobileDevice()) ? 64000 : 256000; // 64kbps mobile/low-band, 256kbps desktop
 
         this.peerConnections.forEach((peer) => {
             peer.connection.getSenders().forEach(sender => {
@@ -2131,7 +2131,7 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
                         parameters.encodings[0].dtx = 'enabled';
                     }
 
-                    parameters.encodings[0].maxBitrate = (this.lowBandwidthMode || this.isMobileDevice()) ? 64000 : 128000;
+                    parameters.encodings[0].maxBitrate = (this.lowBandwidthMode || this.isMobileDevice()) ? 64000 : 256000;
 
                     sender.setParameters(parameters).catch(err => {
                         console.warn('Could not set audio encoding parameters:', err);

--- a/client/debug.html
+++ b/client/debug.html
@@ -70,7 +70,8 @@
         const hostname = window.location.hostname;
         const isLocalhost = hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '';
         const wsProtocol = isLocalhost ? 'ws' : 'wss';
-        const wsUrl = `${wsProtocol}://${hostname}:8765`;
+        const wsPort = window.location.port === '8443' ? '8766' : '8765';
+        const wsUrl = `${wsProtocol}://${hostname}:${wsPort}`;
 
         async function testMedia() {
             const status = document.getElementById('mediaStatus');

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,40 @@
+services:
+  signaling:
+    build:
+      context: ./server
+      dockerfile: Dockerfile
+    env_file:
+      - path: .env
+        required: false
+    ports:
+      - "0.0.0.0:8766:8765"
+      - "[::]:8766:8765"
+    volumes:
+      - ./ssl:/app/ssl:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+    dns:
+      - 8.8.8.8
+      - 1.1.1.1
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.web
+    ports:
+      - "0.0.0.0:8443:443"
+      - "[::]:8443:443"
+    volumes:
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+      - ./logs/nginx:/var/log/nginx
+    restart: unless-stopped
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/fail2ban/jail.local
+++ b/fail2ban/jail.local
@@ -9,9 +9,11 @@ maxretry = 5
 banaction = iptables-multiport
 allowipv6 = auto
 
-# SSH brute force
+# SSH brute force — disabled: port 22 is restricted to whitelisted source IPs at the
+# Linode cloud firewall, so untrusted hosts can't reach sshd. Jail would only risk
+# locking out our own allowed IPs. Re-enable if SSH is ever exposed to 0.0.0.0/0.
 [sshd]
-enabled  = true
+enabled  = false
 port     = ssh
 filter   = sshd
 logpath  = /var/log/auth.log

--- a/update-vps.sh
+++ b/update-vps.sh
@@ -53,9 +53,19 @@ else
 fi
 echo "Updated config/turnserver.production.conf"
 
-# Update primary TURN credential in conference.js (leave turn2Config untouched)
+# Update primary TURN credential in conference.js
 sed -i "s/const PRIMARY_TURN_CREDENTIAL = '[^']*'/const PRIMARY_TURN_CREDENTIAL = '${TURN_PASSWORD}'/" client/conference.js
-echo "Updated client/conference.js"
+echo "Updated client/conference.js (primary TURN credential)"
+
+# Update secondary TURN credential (second VPS) from .env — not rotated here since
+# that coturn lives on another host. Keeps the secret out of git.
+[ -f .env ] && set -a && . ./.env && set +a
+if [ -n "${TURN2_PASSWORD}" ]; then
+    sed -i "s/const SECONDARY_TURN_CREDENTIAL = '[^']*'/const SECONDARY_TURN_CREDENTIAL = '${TURN2_PASSWORD}'/" client/conference.js
+    echo "Updated client/conference.js (secondary TURN credential)"
+else
+    echo "WARNING: TURN2_PASSWORD not set in .env — secondary TURN credential left as placeholder (turn2 relay will fail)"
+fi
 
 # Sync fail2ban config if fail2ban is installed
 if command -v fail2ban-client &>/dev/null; then


### PR DESCRIPTION
## Summary
Brings the `testing` branch work to `main`: new media features, a dev environment, and removal of both TURN credentials from the repo.

## Features
- **Stereo screen-share audio** — dedicated 48 kHz `AudioContext` mixing mic + stereo screen audio, pushed to peers via `replaceTrack`. Context resumes if suspended so the mix is never silent.
- **Noise suppression auto-disables** while screen sharing, restores prior state on stop.
- **4K (2160p) video option** — added to quality selector; `setVideoQuality` now restarts the track (fresh `getUserMedia`) instead of `applyConstraints`, which couldn't change resolution on a live track.
- **Desktop audio bitrate 128k to 256k** (both `applyBandwidthToSenders` and per-sender `setParameters`).
- **Dev environment** on ports 8443 (web) / 8766 (signaling) via `docker-compose.dev.yml`; client auto-detects the dev signaling port.

## Security
- **Both TURN credentials are now placeholders** (`TURN_CREDENTIAL_REDACTED`, `TURN2_CREDENTIAL_REDACTED`) substituted at deploy by `update-vps.sh` from a generated value / `.env` (`TURN2_PASSWORD`). No live TURN secret in the repo.
- **turn2 password rotated** on 174.138.183.167; the value previously in history is now dead.
- **sshd fail2ban jail disabled** — port 22 is restricted to whitelisted IPs at the Linode cloud firewall, making the jail redundant (and a lockout risk).

## Deploy notes (required)
- Prod: `update-vps.sh` substitutes both credentials; **`TURN2_PASSWORD` must be set in the prod `.env`** or turn2 relay fails.
- Dev: `docker-compose.dev.yml` does **not** run `update-vps.sh` yet, so dev will not substitute the turn2 placeholder — follow-up to wire a `sed` step into the dev deploy.
