### PR TITLE
Fix mesh client CPU overload + dev deploy sync

### DIFF
--- a/client/app.html
+++ b/client/app.html
@@ -100,7 +100,6 @@
                             <option value="480">480p</option>
                             <option value="720" selected>720p</option>
                             <option value="1080">1080p</option>
-                            <option value="2160">4K</option>
                         </select>
                     </div>
                     <div class="options-item theme-selector">

--- a/client/conference.js
+++ b/client/conference.js
@@ -1235,7 +1235,6 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
             '480':  { width: { ideal: 854,  max: 854  }, height: { ideal: 480,  max: 480  }, frameRate: { ideal: 24, max: 30 } },
             '720':  { width: { ideal: 1280, max: 1280 }, height: { ideal: 720,  max: 720  }, frameRate: { ideal: 24, max: 30 } },
             '1080': { width: { ideal: 1920, max: 1920 }, height: { ideal: 1080, max: 1080 }, frameRate: { ideal: 24, max: 30 } },
-            '2160': { width: { ideal: 3840 }, height: { ideal: 2160 }, frameRate: { ideal: 30, max: 30 } },
         };
         return qualityMap[this.videoQuality] || qualityMap['720'];
     }
@@ -1963,7 +1962,7 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
     }
 
     applyBandwidthToSenders() {
-        const videoBitrate = this.lowBandwidthMode ? 200000 : undefined; // 200kbps or uncapped
+        const videoBitrate = this.lowBandwidthMode ? 200000 : 1500000; // 200kbps low-band, else 1.5Mbps cap (mesh CPU/bandwidth guard)
         const audioBitrate = (this.lowBandwidthMode || this.isMobileDevice()) ? 64000 : 256000; // 64kbps mobile/low-band, 256kbps desktop
 
         this.peerConnections.forEach((peer) => {
@@ -2141,11 +2140,11 @@ document.getElementById('chatToggleBtn').addEventListener('click', () => this.to
                 }
             }
 
-            // Cap video bitrate in low bandwidth mode
-            if (track.kind === 'video' && this.lowBandwidthMode && sender.getParameters) {
+            // Cap video bitrate (mesh CPU/bandwidth guard): 200kbps low-band, 1.5Mbps otherwise
+            if (track.kind === 'video' && sender.getParameters) {
                 const parameters = sender.getParameters();
                 if (parameters.encodings && parameters.encodings.length > 0) {
-                    parameters.encodings[0].maxBitrate = 200000; // 200kbps video cap
+                    parameters.encodings[0].maxBitrate = this.lowBandwidthMode ? 200000 : 1500000;
                     sender.setParameters(parameters).catch(err => {
                         console.warn('Could not set video encoding parameters:', err);
                     });

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,6 @@
 services:
   signaling:
+    container_name: broference-dev-signaling
     build:
       context: ./server
       dockerfile: Dockerfile
@@ -23,6 +24,7 @@ services:
         max-file: "3"
 
   web:
+    container_name: broference-dev-web
     build:
       context: .
       dockerfile: Dockerfile.web

--- a/server/signaling_server_v2.py
+++ b/server/signaling_server_v2.py
@@ -1169,7 +1169,11 @@ async def main():
     else:
         logger.info("ADMIN_SECRET loaded from environment")
 
-    async with websockets.serve(handler, host, port, ssl=ssl_context, max_size=4*1024*1024):
+    # ping_interval/ping_timeout raised from the 20s default: clients in large mesh
+    # calls can momentarily peg their CPU (per-peer encode/decode) and miss a keepalive
+    # pong, which would otherwise drop them with a 1011 timeout and force a refresh.
+    async with websockets.serve(handler, host, port, ssl=ssl_context, max_size=4*1024*1024,
+                                ping_interval=20, ping_timeout=60):
         await asyncio.Future()  # Run forever
 
 

--- a/update-dev.sh
+++ b/update-dev.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Redeploy the BroFerence dev environment (web :8443, signaling :8766).
+#
+# Dev shares PROD's primary coturn (turn:<host>:3479), so the primary TURN
+# credential is NOT generated here — it is read from .env PRIMARY_PASSWORD,
+# which prod's update-vps.sh propagates on every prod deploy. The secondary
+# (turn2) credential comes from .env TURN2_PASSWORD.
+#
+# Run as a user with Docker access and read/write to this repo (root in our
+# setup, since prod's update-vps.sh invokes this in lockstep).
+set -e
+cd "$(dirname "$(readlink -f "$0")")"
+
+DEV_BRANCH="${DEV_BRANCH:-testing}"
+
+echo "[1/4] Updating dev code (branch: ${DEV_BRANCH})..."
+git fetch origin -q
+git reset --hard "origin/${DEV_BRANCH}"
+
+echo "[2/4] Substituting TURN credentials from .env..."
+[ -f .env ] && set -a && . ./.env && set +a
+if [ -z "${PRIMARY_PASSWORD}" ]; then
+    echo "ERROR: PRIMARY_PASSWORD not set in .env (propagated by prod update-vps.sh). Aborting."
+    exit 1
+fi
+[ -n "${TURN2_PASSWORD}" ] || echo "WARNING: TURN2_PASSWORD not set in .env — turn2 relay will fail"
+sed -i "s/const PRIMARY_TURN_CREDENTIAL = '[^']*'/const PRIMARY_TURN_CREDENTIAL = '${PRIMARY_PASSWORD}'/" client/conference.js
+sed -i "s/const SECONDARY_TURN_CREDENTIAL = '[^']*'/const SECONDARY_TURN_CREDENTIAL = '${TURN2_PASSWORD}'/" client/conference.js
+echo "  primary=${PRIMARY_PASSWORD:0:6}...  turn2=${TURN2_PASSWORD:0:6}..."
+
+echo "[3/4] Cache-busting assets..."
+COMMIT=$(git rev-parse --short HEAD)
+sed -i "s/?v=[^\"']*/?v=${COMMIT}/g" client/app.html
+
+echo "[4/4] Rebuilding dev containers..."
+docker compose -f docker-compose.dev.yml build
+# Clear any pre-compose standalone containers holding the names, then bring up clean.
+docker rm -f broference-dev-web broference-dev-signaling 2>/dev/null || true
+docker compose -f docker-compose.dev.yml up -d
+
+echo ""
+echo "Dev redeploy complete (commit ${COMMIT})."
+docker compose -f docker-compose.dev.yml ps

--- a/update-vps.sh
+++ b/update-vps.sh
@@ -94,6 +94,23 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+# Propagate the rotated primary TURN credential to the dev environment (which
+# shares this coturn) and redeploy it in lockstep, so dev never drifts out of
+# sync. Skipped cleanly if the dev repo/.env isn't present or isn't writable.
+DEV_DIR="${BROFERENCE_DEV_DIR:-/home/interdome/BroFerence-dev}"
+if [ -f "$DEV_DIR/.env" ] && [ -w "$DEV_DIR/.env" ]; then
+    echo ""
+    echo "Syncing dev environment (${DEV_DIR})..."
+    if grep -q '^PRIMARY_PASSWORD=' "$DEV_DIR/.env"; then
+        sed -i "s/^PRIMARY_PASSWORD=.*/PRIMARY_PASSWORD=${TURN_PASSWORD}/" "$DEV_DIR/.env"
+    else
+        echo "PRIMARY_PASSWORD=${TURN_PASSWORD}" >> "$DEV_DIR/.env"
+    fi
+    if [ -f "$DEV_DIR/update-dev.sh" ]; then
+        ( cd "$DEV_DIR" && bash update-dev.sh ) || echo "WARNING: dev redeploy failed (prod is unaffected)"
+    fi
+fi
+
 # Show container status
 echo ""
 echo "[4/4] Checking container status..."


### PR DESCRIPTION
Incident fix: remove 4K, cap video bitrate to 1.5Mbps, raise signaling keepalive ping_timeout 20->60s (clients were dropping with 1011 keepalive timeout from CPU starvation, forcing refresh). Also adds update-dev.sh + lockstep dev sync.